### PR TITLE
✨ support AWS_S3_REGION_NAME in env config for S3 region setting

### DIFF
--- a/web/config/settings.py
+++ b/web/config/settings.py
@@ -282,6 +282,7 @@ FILE_UPLOAD_MAX_MEMORY_SIZE = 52428800  # 50MB
 AWS_S3_ACCESS_KEY_ID = env("AWS_S3_ACCESS_KEY_ID", default="dummy_key")
 AWS_S3_SECRET_ACCESS_KEY = env("AWS_S3_SECRET_ACCESS_KEY", default="dummy_key")
 AWS_STORAGE_BUCKET_NAME = env("AWS_STORAGE_BUCKET_NAME", default="dummy_bucket")
+AWS_S3_REGION_NAME = env("AWS_S3_REGION_NAME", default="us-east-1")
 
 # Svix
 SVIX_TOKEN = env("SVIX_TOKEN", default="")
@@ -307,7 +308,7 @@ STORAGES = {
         "BACKEND": "storages.backends.s3.S3Storage",
         "OPTIONS": {
             "bucket_name": AWS_STORAGE_BUCKET_NAME,
-            "region_name": "us-east-1",  # e.g., 'us-west-1'
+            "region_name": AWS_S3_REGION_NAME # "us-east-1",  # e.g., 'us-west-1'
             "default_acl": None,  # Makes files private by default
             "querystring_auth": True,  # Requires signed URLs for access
             "querystring_expire": 3600,  # Expiry time for signed URLs (1 hour)


### PR DESCRIPTION
## Description

Previously, the code did not support setting the AWS S3 region name through the environment configuration file. This commit adds support for specifying the region using the AWS_S3_REGION_NAME variable, allowing users to configure the S3 region as needed.

## Type of change

<!-- Please select ONE option that best describes your changes -->
<!-- Your selection will determine the semantic version bump -->

- [ ] 🚨 Breaking change - causes existing functionality to break (triggers MAJOR version bump)
- [x] ✨ New feature - adds functionality in a non-breaking way (triggers MINOR version bump)
- [ ] 🐛 Bug fix - fixes an issue without changing functionality (triggers PATCH version bump)
- [ ] 🏠 Internal - changes that don't affect external functionality (no version bump)
      (e.g., refactoring, docs, tests, admin site changes)

## Release Impact

<!-- The following will be automated based on your type of change selection above -->
- Current version: <!-- e.g., v1.2.3 -->
- Next version will be: <!-- will be automatically determined -->

## Checklist

- [ ] My code follows the style guidelines 
- [ ] My code is tested with 99%+ coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated the documentation to reflect my changes
- [ ] I have added/updated tests to cover my changes

## Breaking Changes

<!-- If you checked "Breaking change" above, please detail the breaks here -->
<!-- This will be included in the release notes -->

## Migration Guide

<!-- If you checked "Breaking change" above, please provide migration instructions -->
<!-- This will be included in the release notes -->

## Additional Notes

<!-- Any other information that would be helpful to reviewers -->
